### PR TITLE
Catch against special shorthand cases

### DIFF
--- a/lib/ecma-re-validator.rb
+++ b/lib/ecma-re-validator.rb
@@ -42,6 +42,12 @@ module EcmaReValidator
       return false
     end
 
-    Regexp::Scanner.scan(input).none? { |t| INVALID_TOKENS.include?(t[1]) }
+    Regexp::Scanner.scan(input).none? do |t|
+      if t[1] == :word || t[1] == :space || t[1] == :digit
+        t[0] != :type
+      else
+        INVALID_TOKENS.include?(t[1])
+      end
+    end
   end
 end

--- a/spec/unicode_spec.rb
+++ b/spec/unicode_spec.rb
@@ -95,4 +95,22 @@ describe 'EcmaReValidator::Unicode' do
 
     expect(EcmaReValidator.valid?(re)).to eql(true)
   end
+
+  it 'should pass if regexp uses a \w' do
+    re = /^\w+/
+
+    expect(EcmaReValidator.valid?(re)).to eql(true)
+  end
+
+  it 'should pass if regexp uses a \s' do
+    re = /\s*wow/
+
+    expect(EcmaReValidator.valid?(re)).to eql(true)
+  end
+
+  it 'should pass if regexp uses a \d' do
+    re = /\d$/
+
+    expect(EcmaReValidator.valid?(re)).to eql(true)
+  end
 end


### PR DESCRIPTION
It turns out that [character classes](http://www.regular-expressions.info/posixbrackets.html) erroneously fail, so we should treat the few available in JavaScript as special cases.
