### PR TITLE
Use Rake > 13 to fix CVE-2020-8130

### DIFF
--- a/ecma-re-validator.gemspec
+++ b/ecma-re-validator.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %(Validate a regular expression string against what ECMA-262 can actually do.)
   gem.homepage      = 'https://github.com/gjtorikian/ecma-re-validator'
   gem.license       = 'MIT'
-  gem.files         = `git ls-files -z`.split("\x0")
+  gem.files         = `git ls-files -z`.split("\x0").reject{ |f| f =~ %r{^vendor/.*} }
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ['lib']
 


### PR DESCRIPTION
Reference:
https://hackerone.com/reports/651518
https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2020-8130&vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.1&source=NIST

While this gem doesn't directly expose that vulnerability, it does ship a vulnerable copy of Rake 12.x in the vendor directory; and that will get picked up by some CVE scanners.

This PR cuts the vendor directory from the shipped gem and also bumps the Rake dependency to `> 13`.

Signed-off-by: James Stocks <jstocks@chef.io>